### PR TITLE
Add sed line for curl to handle non-portable sockaddr_storage.__ss_family

### DIFF
--- a/Jenkinsfile.curl.nsblde4
+++ b/Jenkinsfile.curl.nsblde4
@@ -55,6 +55,7 @@ pipeline {
                     sh 'test -f ${DOWNLOADS}/curl-${CURL_VERSION}.tar.gz || curl --insecure ${CURL_URL_PREFIX}curl-${CURL_VERSION}.tar.gz -o ${DOWNLOADS}/curl-${CURL_VERSION}.tar.gz'
                     sh 'tar xzf ${DOWNLOADS}/curl-${CURL_VERSION}.tar.gz'
                     sh 'mv curl-${CURL_VERSION}/* .'
+                    sh 'sed "s/\\.ss_family/.__ss_family/g" -i src/tool_operate.c'
                 }
             }
         }

--- a/Jenkinsfile.curl.tcmvns
+++ b/Jenkinsfile.curl.tcmvns
@@ -46,6 +46,7 @@ pipeline {
                     sh 'test -f ${DOWNLOADS}/curl-${CURL_VERSION}.tar.gz || curl --insecure ${CURL_URL_PREFIX}curl-${CURL_VERSION}.tar.gz -o ${DOWNLOADS}/curl-${CURL_VERSION}.tar.gz'
                     sh 'tar xzf ${DOWNLOADS}/curl-${CURL_VERSION}.tar.gz'
                     sh 'mv curl-${CURL_VERSION}/* .'
+                    sh 'sed "s/\\.ss_family/.__ss_family/g" -i src/tool_operate.c'
                 }
             }
         }


### PR DESCRIPTION
The base curl code uses sockaddr_storage.ss_family, which is not available on NonStop.

Fixes: #24